### PR TITLE
axis info for data is integer, changed to float

### DIFF
--- a/xrdtools/io.py
+++ b/xrdtools/io.py
@@ -254,7 +254,7 @@ def _read_axis_info(uid_pos, n):
     dict
         Axis settings stored in a dictionary.
     """
-    info = {'axis': uid_pos.get('axis'), 'unit': uid_pos.get('unit'), 'data': np.array([0, 0])}
+    info = {'axis': uid_pos.get('axis'), 'unit': uid_pos.get('unit'), 'data': np.array([0.0, 0.0])}
     is_array = True
 
     for child in list(uid_pos):


### PR DESCRIPTION
Normally when dealing with xrdml files, the equipment does not have perfect integer start and end positions in the file. This is the case with all our files. Therefore the array should go from and to floats, like the intervals also are, to represent the proper start and end positions for Theta2.